### PR TITLE
chore: API 응답 구조 변경

### DIFF
--- a/apps/admin/src/shared/kyInstance.ts
+++ b/apps/admin/src/shared/kyInstance.ts
@@ -1,8 +1,7 @@
 import ky from "ky";
 
 export type CustomError = Error & {
-    code?: string;
-    details?: unknown;
+    code: string;
 };
 
 export const api = ky.create({
@@ -18,11 +17,9 @@ export async function fetcher<T>(request: Promise<Response>): Promise<T> {
     const json = await res.json();
 
     if (!res.ok || !json.success) {
-        const baseError = new Error(json.error?.message || "알 수 없는 오류");
-
+        const baseError = new Error();
         const error: CustomError = Object.assign(baseError, {
             code: json.error?.code,
-            details: json.error?.details,
         });
 
         throw error;

--- a/apps/shop/src/shared/fetcher.ts
+++ b/apps/shop/src/shared/fetcher.ts
@@ -3,8 +3,6 @@ type ApiResponse<T> = {
     data: T | null;
     error: {
         code: string;
-        message?: string;
-        details?: Record<string, unknown>;
     } | null;
     message?: string;
 };
@@ -39,12 +37,9 @@ const createFetcher = (url: string, getHeaders?: () => HeadersInit) => {
         }
 
         if (!res.ok || !json.success) {
-            const baseError = new Error(
-                json.error?.message || "알 수 없는 오류",
-            );
+            const baseError = new Error();
             const error: CustomError = Object.assign(baseError, {
                 code: json.error?.code,
-                details: json.error?.details,
             });
 
             throw error;


### PR DESCRIPTION
아래와 같은 구조로 변경하였습니다.

```
{
  "success": true,
  "data": { "orderId": 12345 },
  "error": null,
  "message": "주문이 성공적으로 생성되었습니다." // 선택적 성공 메시지
}
// 실패
{
  "success": false,
  "data": null,
  "error": {
    "code": "ORD-ERR-005"
  },
   "message": "재고 부족" // 에러 메시지와 동일한 메시지
}
```