### PR TITLE
chore: Vercel 배포시 오류 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 
 # Mac OS 시스템 파일
 **/.DS_Store
+
+.turbo

--- a/apps/shop/tsconfig.json
+++ b/apps/shop/tsconfig.json
@@ -25,13 +25,6 @@
         },
         "outDir": "dist"
     },
-    "include": [
-        "**/*.ts",
-        "**/*.tsx",
-        "apps/shop/.next/types/**/*.ts",
-        "next-env.d.ts",
-        ".next/types/**/*.ts",
-        "../admin/src/shared/kyInstance.ts"
-    ],
+    "include": ["**/*.ts", "**/*.tsx", "apps/shop/.next/types/**/*.ts", "next-env.d.ts", ".next/types/**/*.ts"],
     "exclude": ["node_modules"]
 }

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,5 @@
 {
-    "pipeline": {
+    "tasks": {
         "dev": {
             "cache": false,
             "dependsOn": ["^dev"]


### PR DESCRIPTION
- turbo.json에서 pipeline -> tasks로 이름 변경 (최근 이름이 변경됐다고 함)
- shop에서 kyInstance 의존이 포함되어 있어 삭제시킴 (next.js 빌드시 vite.env 포함시 오류)