### PR TITLE
chore: alert 뒷배경은 블러처리 및 상호작용 안되도록 설정

### DIFF
--- a/apps/shop/src/shared/components/shared/ConfirmDialog.tsx
+++ b/apps/shop/src/shared/components/shared/ConfirmDialog.tsx
@@ -13,7 +13,7 @@ interface ConfirmDialogProps {
 export default function ConfirmDialog({ open, title, description, confirmText = "확인", cancelText, onConfirm, onCancel }: ConfirmDialogProps) {
     if (!open) return null;
     return (
-        <div className="fixed inset-0 flex items-center justify-center z-50 backdrop-blur-sm">
+        <div className="fixed inset-0 flex items-center justify-center z-40 backdrop-blur-sm">
             <dialog
                 className="fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-50 max-w-full size-fit bg-white border border-gray-200 shadow-xl rounded-2xl px-16 py-8 flex flex-col items-center"
                 aria-modal="true"

--- a/apps/shop/src/shared/components/shared/ConfirmDialog.tsx
+++ b/apps/shop/src/shared/components/shared/ConfirmDialog.tsx
@@ -13,32 +13,34 @@ interface ConfirmDialogProps {
 export default function ConfirmDialog({ open, title, description, confirmText = "확인", cancelText, onConfirm, onCancel }: ConfirmDialogProps) {
     if (!open) return null;
     return (
-        <dialog
-            className="fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-50 max-w-full size-fit bg-white border border-gray-200 shadow-xl rounded-2xl px-16 py-8 flex flex-col items-center"
-            aria-modal="true"
-            aria-labelledby="confirm-dialog-title"
-            aria-describedby="confirm-dialog-description"
-        >
-            <div className="text-lg font-bold text-[#257A57] mb-2 text-center">{title}</div>
-            <div className="text-gray-700 text-center mb-6 text-base">{description}</div>
-            <div className="flex gap-3 w-full justify-center mx-8">
-                {cancelText && (
+        <div className="fixed inset-0 flex items-center justify-center z-50 backdrop-blur-sm">
+            <dialog
+                className="fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-50 max-w-full size-fit bg-white border border-gray-200 shadow-xl rounded-2xl px-16 py-8 flex flex-col items-center"
+                aria-modal="true"
+                aria-labelledby="confirm-dialog-title"
+                aria-describedby="confirm-dialog-description"
+            >
+                <div className="text-lg font-bold text-[#257A57] mb-2 text-center">{title}</div>
+                <div className="text-gray-700 text-center mb-6 text-base">{description}</div>
+                <div className="flex gap-3 w-full justify-center mx-8">
+                    {cancelText && (
+                        <button
+                            type="button"
+                            className="flex-1 py-2 rounded border border-gray-300 text-gray-700 bg-white hover:bg-gray-100 transition"
+                            onClick={onCancel}
+                        >
+                            {cancelText}
+                        </button>
+                    )}
                     <button
                         type="button"
-                        className="flex-1 py-2 rounded border border-gray-300 text-gray-700 bg-white hover:bg-gray-100 transition"
-                        onClick={onCancel}
+                        className="flex-1 py-2 rounded bg-[#257A57] text-white font-semibold hover:bg-[#1f5c44] transition"
+                        onClick={onConfirm}
                     >
-                        {cancelText}
+                        {confirmText}
                     </button>
-                )}
-                <button
-                    type="button"
-                    className="flex-1 py-2 rounded bg-[#257A57] text-white font-semibold hover:bg-[#1f5c44] transition"
-                    onClick={onConfirm}
-                >
-                    {confirmText}
-                </button>
-            </div>
-        </dialog>
+                </div>
+            </dialog>
+        </div>
     );
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e7f17177-1d7c-477d-9d70-3076a4fd0520)

alert에 같이 처리되었어야 하는 스타일 요소였는데 깜빡해서 다시 올립니다.
뒷배경을 검게 처리안한이유는 bg-black/50 을 준 몇몇 팝업이 있어서 혹시나 겹칠까봐서인데 필요하면 추가해도 됩니다.