### PR TITLE
feat: 장바구니 비었을 때의 UI 추가, 장바구니 실 API와 비교하여 필드 이름 등 수정

### DIFF
--- a/apps/shop/app/cart/page.tsx
+++ b/apps/shop/app/cart/page.tsx
@@ -9,12 +9,10 @@ import Loading from "@/src/shared/components/shared/Loading";
 import { ErrorBoundary } from "@/src/shared/components/shared/ErrorBoundary";
 
 function CartPageClient() {
-    const userId = 1;
-    const { data, isLoading, isError, error } = useCart(userId);
+    const { data, isLoading, isError, error } = useCart();
 
-    const items = data?.items ?? [];
+    const items = data?.cartItems ?? [];
     const inStockItems = items.filter(item => item.stockQuantity >= item.quantity);
-
     return (
         <div className="flex flex-col lg:flex-row justify-center items-center max-w-screen-xl mx-auto px-2 lg:px-8">
             <CartSectionLayout>
@@ -26,7 +24,6 @@ function CartPageClient() {
                     <CartProduct cartItems={items} />
                 )}
             </CartSectionLayout>
-            <div className="self-stretch flex-grow-0 flex-shrink-0 h-3 bg-[#70737c]/[0.08]" />
             <CartSectionLayout>
                 <Summary cartItems={inStockItems} />
             </CartSectionLayout>

--- a/apps/shop/src/features/cart/components/CartProduct.tsx
+++ b/apps/shop/src/features/cart/components/CartProduct.tsx
@@ -36,12 +36,9 @@ export default function CartProduct({ cartItems }: { cartItems: CartItem[] }) {
 
     const deleteCartItems = useMutation({
         mutationFn: async (cartItemIds: number[]) => {
-            const requestBody: { cartItemIds: number[] } = { cartItemIds };
-
-            await fetch("/carts/delete", {
-                method: "POST",
+            await fetch(`/cart-items/delete?cartItemIds=${cartItemIds.join(",")}`, {
+                method: "DELETE",
                 headers: { "Content-Type": "application/json" },
-                body: JSON.stringify(requestBody),
             });
         },
         onSuccess: () => {

--- a/apps/shop/src/features/cart/components/CartProduct.tsx
+++ b/apps/shop/src/features/cart/components/CartProduct.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Item from "./Item";
+import EmptyCart from "./EmptyCart";
 import { useState } from "react";
 import { type CustomError, fetchClient } from "@/src/shared/fetcher";
 import type { CartItem } from "@/src/features/cart/types/cart";
@@ -34,11 +35,11 @@ export default function CartProduct({ cartItems }: { cartItems: CartItem[] }) {
     };
 
     const deleteCartItems = useMutation({
-        mutationFn: async (productIds: number[]) => {
-            const requestBody: { productIds: number[] } = { productIds };
+        mutationFn: async (cartItemIds: number[]) => {
+            const requestBody: { cartItemIds: number[] } = { cartItemIds };
 
-            await fetch("/cart/items", {
-                method: "DELETE",
+            await fetch("/carts/delete", {
+                method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify(requestBody),
             });
@@ -60,11 +61,15 @@ export default function CartProduct({ cartItems }: { cartItems: CartItem[] }) {
     const onDelete = (id: number) => {
         deleteCartItems.mutate([id]);
     };
-
     const onDeleteAll = () => {
         if (selectedItemIds.length === 0) return;
         deleteCartItems.mutate(selectedItemIds);
     };
+
+    // 장바구니가 비어있는 경우 EmptyCart 컴포넌트 표시
+    if (cartItems.length === 0) {
+        return <EmptyCart />;
+    }
 
     return (
         <>
@@ -86,7 +91,7 @@ export default function CartProduct({ cartItems }: { cartItems: CartItem[] }) {
                 <Item
                     key={item.cartItemId}
                     productId={item.productId}
-                    name={item.name}
+                    name={item.productName}
                     price={item.price}
                     quantity={item.quantity}
                     stockQuantity={item.stockQuantity}

--- a/apps/shop/src/features/cart/components/CartProduct.tsx
+++ b/apps/shop/src/features/cart/components/CartProduct.tsx
@@ -90,7 +90,7 @@ export default function CartProduct({ cartItems }: { cartItems: CartItem[] }) {
             {cartItems.map(item => (
                 <Item
                     key={item.cartItemId}
-                    productId={item.productId}
+                    cartItemId={item.cartItemId}
                     name={item.productName}
                     price={item.price}
                     quantity={item.quantity}

--- a/apps/shop/src/features/cart/components/EmptyCart.tsx
+++ b/apps/shop/src/features/cart/components/EmptyCart.tsx
@@ -1,0 +1,20 @@
+import Link from "next/link";
+
+export default function EmptyCart() {
+    return (
+        <div className="flex flex-col items-center justify-center py-16 px-8 text-center">
+            <h2 className="text-xl font-bold text-gray-900 mb-2">장바구니가 비어있습니다</h2>
+            <p className="text-gray-600 mb-8 max-w-md">
+                아직 상품을 담지 않으셨네요.
+                <br />
+                원하는 상품을 장바구니에 담아보세요.
+            </p>
+            <Link
+                href="/main"
+                className="inline-flex items-center px-6 py-3 bg-[#257a57] text-white font-semibold rounded-lg hover:bg-[#1f6b4a] transition-colors"
+            >
+                쇼핑 계속하기
+            </Link>
+        </div>
+    );
+}

--- a/apps/shop/src/features/cart/components/Item.tsx
+++ b/apps/shop/src/features/cart/components/Item.tsx
@@ -5,7 +5,7 @@ import QuantityChange from "./QuantityChange";
 import { formatNumber } from "@/src/shared/utils/formatUtils";
 
 interface ItemProps {
-    productId: number;
+    cartItemId: number;
     name: string;
     price: number;
     quantity: number;
@@ -16,7 +16,7 @@ interface ItemProps {
     onDelete: () => void;
 }
 
-export default function Item({ productId, name, price, quantity, stockQuantity, image, selected, onSelectChange, onDelete }: ItemProps) {
+export default function Item({ cartItemId, name, price, quantity, stockQuantity, image, selected, onSelectChange, onDelete }: ItemProps) {
     const totalPrice = quantity * price;
 
     const getQuantityMessage = () => {
@@ -48,7 +48,7 @@ export default function Item({ productId, name, price, quantity, stockQuantity, 
                                 ({quantity} x &#8361;{formatNumber(price)})
                             </p>
                         </div>
-                        <QuantityChange productId={productId} initQuantity={quantity} stockQuantity={stockQuantity} />
+                        <QuantityChange cartItemId={cartItemId} initQuantity={quantity} stockQuantity={stockQuantity} />
                     </div>
                     <div>{stockQuantity < 1 && <p className="text-red-500 text-xs font-bold mt-2">{getQuantityMessage()}</p>}</div>
                 </div>

--- a/apps/shop/src/features/cart/components/QuantityChange.tsx
+++ b/apps/shop/src/features/cart/components/QuantityChange.tsx
@@ -37,11 +37,10 @@ export default function QuantityChange({ cartItemId, initQuantity, stockQuantity
 
     const changeQuantity = (newQuantity: number) => {
         const requestBody: UpdateCartItemRequest = {
-            cartItemId,
             quantity: newQuantity,
         };
 
-        fetch<UpdateCartItemResponse>("/cart/items", {
+        fetch<UpdateCartItemResponse>(`/cart/items/${cartItemId}`, {
             method: "PATCH",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(requestBody),

--- a/apps/shop/src/features/cart/components/QuantityChange.tsx
+++ b/apps/shop/src/features/cart/components/QuantityChange.tsx
@@ -7,12 +7,12 @@ import { useEffect, useState } from "react";
 import type { UpdateCartItemRequest, UpdateCartItemResponse } from "../types/cart";
 
 type QuantityChangeProps = {
-    productId: number;
+    cartItemId: number;
     initQuantity: number;
     stockQuantity: number;
 };
 
-export default function QuantityChange({ productId, initQuantity, stockQuantity }: QuantityChangeProps) {
+export default function QuantityChange({ cartItemId, initQuantity, stockQuantity }: QuantityChangeProps) {
     const [quantity, setQuantity] = useState<number>(initQuantity);
     const { toast, ToastUI } = useToast();
     const fetch = fetchClient();
@@ -37,7 +37,7 @@ export default function QuantityChange({ productId, initQuantity, stockQuantity 
 
     const changeQuantity = (newQuantity: number) => {
         const requestBody: UpdateCartItemRequest = {
-            productId,
+            cartItemId,
             quantity: newQuantity,
         };
 

--- a/apps/shop/src/features/cart/components/QuantityChange.tsx
+++ b/apps/shop/src/features/cart/components/QuantityChange.tsx
@@ -40,7 +40,7 @@ export default function QuantityChange({ cartItemId, initQuantity, stockQuantity
             quantity: newQuantity,
         };
 
-        fetch<UpdateCartItemResponse>(`/cart/items/${cartItemId}`, {
+        fetch<UpdateCartItemResponse>(`/cart-items/${cartItemId}`, {
             method: "PATCH",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(requestBody),

--- a/apps/shop/src/features/cart/components/Summary.tsx
+++ b/apps/shop/src/features/cart/components/Summary.tsx
@@ -24,7 +24,7 @@ export default function Summary({ cartItems }: { cartItems: CartItem[] }) {
             {cartItems.map(item => (
                 <div key={item.cartItemId} className="flex justify-between w-full items-center mt-2">
                     <p className="text-sm text-left text-[#47484C]">
-                        {item.name}(x{item.quantity})
+                        {item.productName}(x{item.quantity})
                     </p>
                     <p>&#8361; {formatNumber(item.price)}</p>
                 </div>

--- a/apps/shop/src/features/cart/hooks/useCart.ts
+++ b/apps/shop/src/features/cart/hooks/useCart.ts
@@ -2,18 +2,18 @@ import { useQuery } from "@tanstack/react-query";
 import { type CustomError, fetchClient } from "@/src/shared/fetcher";
 import type { GetCartResponse } from "@/src/features/cart/types/cart";
 
-export function useCart(userId: number) {
+export function useCart() {
     return useQuery<GetCartResponse>({
-        queryKey: ["cart", userId],
-        queryFn: () => fetchCart(userId),
+        queryKey: ["cart"],
+        queryFn: () => fetchCart(),
     });
 }
 
-async function fetchCart(userId: number): Promise<GetCartResponse> {
+async function fetchCart(): Promise<GetCartResponse> {
     const fetch = fetchClient();
 
     try {
-        const res = await fetch<GetCartResponse>(`/cart?userId=${userId}`);
+        const res = await fetch<GetCartResponse>("/carts");
 
         if (!res.data) {
             throw new Error("카트 데이터를 불러올 수 없습니다");

--- a/apps/shop/src/features/cart/hooks/useCart.ts
+++ b/apps/shop/src/features/cart/hooks/useCart.ts
@@ -13,7 +13,7 @@ async function fetchCart(): Promise<GetCartResponse> {
     const fetch = fetchClient();
 
     try {
-        const res = await fetch<GetCartResponse>("/carts");
+        const res = await fetch<GetCartResponse>("/cart-items");
 
         if (!res.data) {
             throw new Error("카트 데이터를 불러올 수 없습니다");

--- a/apps/shop/src/features/cart/types/cart.ts
+++ b/apps/shop/src/features/cart/types/cart.ts
@@ -1,7 +1,7 @@
 export interface CartItem {
     cartItemId: number;
     productId: number;
-    name: string;
+    productName: string;
     price: number;
     quantity: number;
     stockQuantity: number;
@@ -10,7 +10,7 @@ export interface CartItem {
 }
 
 export interface GetCartResponse {
-    items: CartItem[];
+    cartItems: CartItem[];
     totalPrice: number;
     deliveryPrice: number;
 }

--- a/apps/shop/src/features/cart/types/cart.ts
+++ b/apps/shop/src/features/cart/types/cart.ts
@@ -15,7 +15,7 @@ export interface GetCartResponse {
     deliveryPrice: number;
 }
 
-// 상품 추가 (POST /cart/items?userId={})
+// 상품 추가 (POST /cart-items)
 export interface AddCartItemRequest {
     productId: number;
     quantity: number;
@@ -27,7 +27,7 @@ export interface AddCartItemResponse {
     requiresQuantityAdjustment: boolean;
 }
 
-// 수량 수정 (PATCH /cart/items/{cartItemid})
+// 수량 수정 (PATCH /cart-items/{cartItemid})
 export interface UpdateCartItemRequest {
     quantity: number;
 }
@@ -39,7 +39,7 @@ export interface UpdateCartItemResponse {
     requiresQuantityAdjustment: boolean;
 }
 
-// 삭제 (DELETE /carts)
+// 삭제 (DELETE /cart-items/delete)
 export interface DeleteCartItemsRequest {
     productIds: number[];
 }

--- a/apps/shop/src/features/cart/types/cart.ts
+++ b/apps/shop/src/features/cart/types/cart.ts
@@ -29,7 +29,7 @@ export interface AddCartItemResponse {
 
 // 수량 수정 (PATCH /cart/items/{cartItemid})
 export interface UpdateCartItemRequest {
-    productId: number;
+    cartItemId: number;
     quantity: number;
 }
 

--- a/apps/shop/src/features/cart/types/cart.ts
+++ b/apps/shop/src/features/cart/types/cart.ts
@@ -29,7 +29,6 @@ export interface AddCartItemResponse {
 
 // 수량 수정 (PATCH /cart/items/{cartItemid})
 export interface UpdateCartItemRequest {
-    cartItemId: number;
     quantity: number;
 }
 

--- a/apps/shop/src/features/order/components/OrderCheckoutPage.tsx
+++ b/apps/shop/src/features/order/components/OrderCheckoutPage.tsx
@@ -13,7 +13,7 @@ export default function OrderCheckoutPage() {
         {
             cartItemId: 1,
             productId: 1,
-            name: "상품 1",
+            productName: "상품 1",
             price: 10000,
             quantity: 2,
             stockQuantity: 5,
@@ -23,7 +23,7 @@ export default function OrderCheckoutPage() {
         {
             cartItemId: 2,
             productId: 2,
-            name: "상품 2",
+            productName: "상품 2",
             price: 20000,
             quantity: 1,
             stockQuantity: 3,
@@ -112,7 +112,7 @@ export default function OrderCheckoutPage() {
                                     <OrderCheckoutList
                                         items={cartItems.map(item => ({
                                             id: item.cartItemId,
-                                            name: item.name,
+                                            name: item.productName,
                                             price: item.price,
                                             quantity: item.quantity,
                                             image: item.thumbnail,

--- a/apps/shop/src/features/order/components/PaymentSummary.tsx
+++ b/apps/shop/src/features/order/components/PaymentSummary.tsx
@@ -18,7 +18,7 @@ export default function PaymentSummary({ cartItems }: PaymentSummaryProps) {
                 <ul>
                     {cartItems.map(item => (
                         <li key={item.cartItemId} className="flex justify-between items-center mb-4">
-                            <span>{item.name}</span>
+                            <span>{item.productName}</span>
                             <span>₩ {item.price}</span>
                         </li>
                     ))}

--- a/apps/shop/src/features/product/components/AddToCart.tsx
+++ b/apps/shop/src/features/product/components/AddToCart.tsx
@@ -55,7 +55,7 @@ export default function AddToCart({ productId, title, stockQuantity, withPopup =
 
     const addToCart = (quantity: number) => {
         const fetch = fetchClient();
-        fetch<AddCartItemResponse>("/cart/items", {
+        fetch<AddCartItemResponse>("/cart-items", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5ef2de56-9937-4fa5-89f4-317761dda015)

- 장바구니 조회, 삭제 기능 동작 확인
- **수량 수정 기능 오작동 (조율 필요) <- 이거 한 후에 draft 풀 예정**
- 장바구니 추가 기능은 현재 상품 정보가 없어서 확인되지 않으나 API 타입 형태는 같음 (추후 상품 목록 조회되면 재확인 필요)