### PR TITLE
메인 페이지 카테고리 그리드 UI 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 **/.DS_Store
 
 .turbo
+/.windsurf

--- a/apps/shop/src/features/main/components/CategoryGrid.tsx
+++ b/apps/shop/src/features/main/components/CategoryGrid.tsx
@@ -13,7 +13,7 @@ export default async function CategoryGrid() {
                     <CategoryNav />
                 </div>
 
-                <div className="grid grid-cols-2 md:grid-cols-4 gap-3 w-full">
+                <div className="grid grid-cols-2 sm:grid-cols-4 gap-5 w-full">
                     {categories.map(category => (
                         <CategoryItem key={category.id} title={category.title} description={category.description} imageUrl={category.imageUrl} />
                     ))}

--- a/apps/shop/src/features/main/components/CategoryItem.tsx
+++ b/apps/shop/src/features/main/components/CategoryItem.tsx
@@ -6,11 +6,11 @@ interface CategoryItemProps {
 
 export function CategoryItem({ title, description, imageUrl }: CategoryItemProps) {
     return (
-        <div className="flex flex-col items-center">
-            <div className="w-full h-36 overflow-hidden rounded-t-lg bg-gray-100 flex items-center justify-center">
-                <img src={imageUrl} alt={title} className="w-24 h-24 object-contain" />
+        <div className="flex flex-col h-full max-w-full">
+            <div className="w-full h-36 overflow-hidden rounded-t-lg bg-gray-100 flex items-center justify-center flex-shrink-0">
+                <img src={imageUrl} alt={title} className="w-24 h-24 object-contain break-keep" />
             </div>
-            <div className="flex flex-col items-center text-center bg-black text-white w-full p-4 rounded-b-lg">
+            <div className="flex flex-col items-center justify-center text-center bg-black text-white w-full p-4 rounded-b-lg break-keep flex-1 min-h-[120px]">
                 <h3 className="text-base font-bold mb-1">{title}</h3>
                 <p className="text-sm text-white/80">{description}</p>
             </div>


### PR DESCRIPTION
<img width="783" alt="스크린샷 2025-06-14 오후 12 18 05" src="https://github.com/user-attachments/assets/84616dc5-9dc7-430b-832c-feb08754de83" />

각 아이템 텍스트 라인수가 차이가 나는경우 UI가 어색한 부분을 개선하였습니다.